### PR TITLE
Add OpenTelemetry tracing to Web API

### DIFF
--- a/api/Directory.Packages.props
+++ b/api/Directory.Packages.props
@@ -16,6 +16,11 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Npgsql" Version="8.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
     <PackageVersion Include="xunit" Version="2.6.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/api/Essence.WebAPI/Essence.WebAPI.csproj
+++ b/api/Essence.WebAPI/Essence.WebAPI.csproj
@@ -5,10 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Essence.Base\Essence.Base.csproj" />
     <ProjectReference Include="..\Essence.Domain.Infrastructure\Essence.Domain.Infrastructure.csproj" />
     <ProjectReference Include="..\Essence.Domain\Essence.Domain.csproj" />
     <ProjectReference Include="..\Essence.Persistence.Infrastructure\Essence.Persistence.Infrastructure.csproj" />
   </ItemGroup>
-
 </Project>

--- a/api/Essence.WebAPI/Program.cs
+++ b/api/Essence.WebAPI/Program.cs
@@ -41,11 +41,9 @@ public class Program
         var tracingOtlpEndpoint = builder.Configuration["OTLP_ENDPOINT_URL"];
         var otel = builder.Services.AddOpenTelemetry();
         
-        // Configure OpenTelemetry Resources with the application name
         otel.ConfigureResource(resource => resource
             .AddService(serviceName: builder.Environment.ApplicationName));
         
-        // Add Tracing for ASP.NET Core and our custom ActivitySource and export to Jaeger
         otel.WithTracing(tracing =>
         {
             tracing.AddAspNetCoreInstrumentation();
@@ -58,7 +56,7 @@ public class Program
                      otlpOptions.Endpoint = new Uri(tracingOtlpEndpoint);
                  });
             }
-//            else
+            else
             {
                 tracing.AddConsoleExporter();
             }

--- a/api/Essence.WebAPI/Program.cs
+++ b/api/Essence.WebAPI/Program.cs
@@ -50,9 +50,9 @@ public class Program
         {
             tracing.AddAspNetCoreInstrumentation();
             tracing.AddHttpClientInstrumentation();
-            Console.WriteLine(tracingOtlpEndpoint ?? "<NULL>");
             if (tracingOtlpEndpoint != null)
             {
+                Console.WriteLine(tracingOtlpEndpoint ?? "<NULL>");
                 tracing.AddOtlpExporter(otlpOptions =>
                  {
                      otlpOptions.Endpoint = new Uri(tracingOtlpEndpoint);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,17 +37,6 @@ services:
     depends_on:
       - elasticsearch
 
-  hotrod:
-    image: jaegertracing/example-hotrod:latest
-    ports:
-      - 8080:8080
-      - 8083:8083
-    command: ["all"]
-    environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector:4318
-    depends_on:
-      - jaeger-collector
-
   database:
     image: postgres
     restart: always
@@ -66,8 +55,7 @@ services:
     env_file:
       - .env
     environment:
-      - OTLP_ENDPOINT_URL=http://jaeger-collector:4318
-      - OTEL_LOG_LEVEL=debug
+      - OTLP_ENDPOINT_URL=http://jaeger-collector:4317
     ports:
       - 5011:5010
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,63 @@
 version: "3.7"
 services:
+  elasticsearch:
+    image: elasticsearch:8.11.3
+    ports:
+      - 9200:9200
+      - 9300:9300
+    restart: on-failure
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+
+  jaeger-query:
+    image: jaegertracing/jaeger-query:1.52
+    ports:
+      - 16685:16685
+      - 16686:16686
+      - 16687:16687
+    restart: on-failure
+    environment:
+      - SPAN_STORAGE_TYPE=elasticsearch
+      - ES_SERVER_URLS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+
+  jaeger-collector:
+    image: jaegertracing/jaeger-collector:1.52
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 14268:14268
+      - 14269:14269
+    restart: on-failure
+    environment:
+      - SPAN_STORAGE_TYPE=elasticsearch
+      - ES_SERVER_URLS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+
+  hotrod:
+    image: jaegertracing/example-hotrod:latest
+    ports:
+      - 8080:8080
+      - 8083:8083
+    command: ["all"]
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector:4318
+    depends_on:
+      - jaeger-collector
+
   database:
     image: postgres
     restart: always
     env_file:
       - .env
     ports:
-      - "5433:5432"
+      - 5433:5432
     volumes:
       - ./db/:/docker-entrypoint-initdb.d/
+
   api:
     build:
       context: api
@@ -16,10 +65,15 @@ services:
     restart: always
     env_file:
       - .env
+    environment:
+      - OTLP_ENDPOINT_URL=http://jaeger-collector:4318
+      - OTEL_LOG_LEVEL=debug
     ports:
-      - "5011:5010"
+      - 5011:5010
     depends_on:
       - database
+      - jaeger-collector
+
   app:
     build:
       context: app
@@ -28,7 +82,8 @@ services:
     env_file:
       - .env
     ports:
-      - "90:80"
+      - 90:80
     depends_on:
       - database
       - api
+


### PR DESCRIPTION
- Introduce automatic tracing of requests to Web API with OpenTelemetry
- Configure OpenTelemetry exporter to Jaeger Collector with gRPC protocol
- Configure Jaeger and Elasticsearch to run in Docker